### PR TITLE
Fixed error caused by lines of data without ":" to use when exploding

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -110,8 +110,11 @@ class Exporter
         $lines = explode("\n", $status);
         foreach ($lines as $line) {
             if (!empty($line)) {
-                [$key, $value] = explode(': ', $line);
-                $r[$key] = $value;
+                $explodedLine = explode(': ', $line);
+                if (count($explodedLine) == 2) {
+                    [$key, $value] = $explodedLine;
+                    $r[$key] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
Some apache status pages have a line at the start containing the hostname like so: 
```
localhost
ServerVersion: Apache/2.4.35 (Unix) PHP/7.2.13 LibreSSL/2.7.4
ServerMPM: prefork
Server Built: Oct 28 2018 13:27:35
CurrentTime: Wednesday, 19-Dec-2018 17:09:12 
RestartTime: Wednesday, 19-Dec-2018 16:14:28 
...
```

Since there is no `:` to explode the string, the command fails as there is nothing at index 1 of the array. So I added a check to make sure the length of the explode result is 2, else ignore the entry. 